### PR TITLE
Add Foundry deployment workflow via Pod SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ Comprehensive launchpad and DEX stack for pETH-native chains. The system bootstr
 ## Packages
 - **contracts/** – Solidity sources for launchpad, bonding curve, DEX, and shared libraries.
 - **scripts/** – Hardhat deployment helper (offline-ready).
+- **script/** – Foundry deployment entry points and Pod SDK bridge.
 - **test/** – Static configuration checks executed via `npm test`.
 - **docs/** – Architecture overview and integration notes.
 
 ## Requirements
 - Node.js 18+
 - Hardhat (optional, required for Solidity compilation)
+- Foundry (optional, required for Foundry-driven scripting)
 
 ## Usage
 ```bash
@@ -23,10 +25,22 @@ To deploy contracts once Hardhat dependencies are installed:
 npx hardhat run --network <network> scripts/deploy.js
 ```
 
+### Foundry + Pod SDK workflow
+| Step | Command | Notes |
+| ---- | ------- | ----- |
+| 1 | `forge build` | Aligns bytecode/ABIs with Hardhat (solc 0.8.19, 800 optimizer runs). |
+| 2 | `export POD_RPC_URL=...`<br>`export POD_PRIVATE_KEY=0x...`<br>`export POD_GUARDIAN_ADDRESS=0x...` | Guardian defaults to the broadcaster when unset. Keep keys outside shell history. |
+| 3 | `forge script script/Deploy.s.sol:DeployScript --ffi --broadcast` | Delegates to `script/deploy-with-pod.js`, which composes legacy `PodTransactionRequest`s and persists `deployment-foundry.json`. |
+
+The helper script enforces legacy transactions through `PodProviderBuilder` and writes deployment metadata mirroring the Hardhat flow. Supply `--legacy` if your Foundry toolchain requires explicit flags.
+
 ### Environment Variables (`.env`)
 - `deployer_private_key`
 - `peth_rpc_url`
 - `protocol_guardian_address`
+- `POD_PRIVATE_KEY`
+- `POD_RPC_URL`
+- `POD_GUARDIAN_ADDRESS`
 
 ## Security Practices
 - All state-mutating endpoints include validation, reentrancy guards, and emergency pause controls.

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.19"
+optimizer = true
+optimizer_runs = 800
+ffi = true
+
+[rpc_endpoints]
+pod = "${POD_RPC_URL}"

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "ethers": "^6.12.2",
+    "pod-sdk": "^0.1.0"
+  }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import "forge-std/Script.sol";
+
+/// @notice Entry point that delegates on-chain deployment to the Pod SDK helper.
+/// @dev The heavy lifting lives in `script/deploy-with-pod.js`, which uses the Pod SDK
+///      to broadcast legacy transactions constructed from Foundry build artifacts.
+contract DeployScript is Script {
+    function run() external {
+        string memory projectRoot = vm.projectRoot();
+        string[] memory cmd = new string[](3);
+        cmd[0] = "node";
+        cmd[1] = string.concat(projectRoot, "/script/deploy-with-pod.js");
+        cmd[2] = projectRoot;
+
+        // Executes the Node.js helper which performs deployment via the Pod SDK.
+        vm.ffi(cmd);
+    }
+}

--- a/script/deploy-with-pod.js
+++ b/script/deploy-with-pod.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/*
+  Foundry-driven deployment helper that mirrors scripts/deploy.js while
+  leveraging the Pod SDK for transaction submission.
+
+  Required env vars:
+    POD_RPC_URL        - target RPC endpoint
+    POD_PRIVATE_KEY    - hex private key (0x...)
+    POD_GUARDIAN_ADDRESS (optional) - guardian wallet, defaults to deployer
+*/
+
+const fs = require('fs');
+const path = require('path');
+const { Interface, JsonRpcProvider, Wallet } = require('ethers');
+const {
+  PodProviderBuilder,
+  PodTransactionRequest
+} = require('pod-sdk');
+
+function createPodTransactionRequest(init) {
+  if (PodTransactionRequest && typeof PodTransactionRequest.from === 'function') {
+    return PodTransactionRequest.from(init);
+  }
+  return new PodTransactionRequest(init);
+}
+
+async function buildSigner(rpcUrl, privateKey) {
+  if (!rpcUrl) {
+    throw new Error('POD_RPC_URL is required');
+  }
+  if (!privateKey) {
+    throw new Error('POD_PRIVATE_KEY is required');
+  }
+
+  // Pod SDK provider handles signing + transport while enforcing legacy mode.
+  const podProvider = await new PodProviderBuilder()
+    .withRpcUrl(rpcUrl)
+    .withLegacyTransactions()
+    .build();
+
+  const provider = new JsonRpcProvider(rpcUrl);
+  const wallet = new Wallet(privateKey, provider);
+  return { podProvider, provider, wallet };
+}
+
+function readArtifact(projectRoot, relativePath, contractName) {
+  const artifactPath = path.join(
+    projectRoot,
+    'out',
+    `${relativePath}.sol`,
+    `${contractName}.json`
+  );
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(`Missing artifact for ${contractName} at ${artifactPath}`);
+  }
+  return JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+}
+
+function buildDeploymentRequest(artifact, constructorArgs, gasPrice) {
+  const iface = new Interface(artifact.abi);
+  const encodedArgs = iface.encodeDeploy(constructorArgs ?? []);
+  const bytecode = artifact.bytecode && artifact.bytecode.object;
+  if (!bytecode || bytecode === '0x') {
+    throw new Error('Artifact does not contain bytecode');
+  }
+
+  const data = `${bytecode}${encodedArgs.slice(2)}`;
+  const requestInit = {
+    to: undefined,
+    data,
+    legacy: true,
+    value: 0n
+  };
+
+  if (gasPrice) {
+    requestInit.gasPrice = BigInt(gasPrice);
+  }
+
+  return createPodTransactionRequest(requestInit);
+}
+
+async function broadcastDeployment(name, request, wallet, provider, podProvider) {
+  const nonce = await provider.getTransactionCount(wallet.address);
+  const gasPrice = request.gasPrice ?? (await provider.getGasPrice());
+  const tx = {
+    to: request.to,
+    data: request.data,
+    gasLimit: request.gasLimit ?? 6_000_000n,
+    gasPrice,
+    nonce,
+    value: request.value ?? 0n,
+    type: 0
+  };
+
+  const signedTx = await wallet.signTransaction(tx);
+  const broadcastFn =
+    podProvider.broadcastTransaction ||
+    podProvider.sendRawTransaction ||
+    podProvider.sendTransaction;
+  if (typeof broadcastFn !== 'function') {
+    throw new Error('Pod provider cannot broadcast raw transactions');
+  }
+
+  const receipt = await broadcastFn.call(podProvider, signedTx);
+  if (!receipt || !receipt.contractAddress) {
+    throw new Error(`Failed to deploy ${name}`);
+  }
+  return receipt.contractAddress;
+}
+
+async function main() {
+  const projectRoot = process.argv[2] || process.cwd();
+  const rpcUrl = process.env.POD_RPC_URL;
+  const privateKey = process.env.POD_PRIVATE_KEY;
+  const guardianEnv = process.env.POD_GUARDIAN_ADDRESS;
+
+  const { podProvider, provider, wallet } = await buildSigner(rpcUrl, privateKey);
+  const deployer = await wallet.getAddress();
+  const guardian = guardianEnv && guardianEnv !== '' ? guardianEnv : deployer;
+
+  const gasPrice = await provider.getGasPrice();
+
+  const treasuryArtifact = readArtifact(
+    projectRoot,
+    'core/ProtocolTreasury',
+    'ProtocolTreasury'
+  );
+  const treasuryRequest = buildDeploymentRequest(
+    treasuryArtifact,
+    [deployer, guardian],
+    gasPrice
+  );
+  const treasuryAddress = await broadcastDeployment(
+    'ProtocolTreasury',
+    treasuryRequest,
+    wallet,
+    provider,
+    podProvider
+  );
+
+  const dexFactoryArtifact = readArtifact(projectRoot, 'dex/DEXFactory', 'DEXFactory');
+  const dexFactoryRequest = buildDeploymentRequest(
+    dexFactoryArtifact,
+    [treasuryAddress, deployer],
+    gasPrice
+  );
+  const dexFactoryAddress = await broadcastDeployment(
+    'DEXFactory',
+    dexFactoryRequest,
+    wallet,
+    provider,
+    podProvider
+  );
+
+  const dexRouterArtifact = readArtifact(projectRoot, 'dex/DEXRouter', 'DEXRouter');
+  const dexRouterRequest = buildDeploymentRequest(
+    dexRouterArtifact,
+    [dexFactoryAddress],
+    gasPrice
+  );
+  const dexRouterAddress = await broadcastDeployment(
+    'DEXRouter',
+    dexRouterRequest,
+    wallet,
+    provider,
+    podProvider
+  );
+
+  const launchpadArtifact = readArtifact(
+    projectRoot,
+    'core/LaunchpadFactory',
+    'LaunchpadFactory'
+  );
+  const launchpadRequest = buildDeploymentRequest(
+    launchpadArtifact,
+    [deployer, dexFactoryAddress, dexRouterAddress, guardian],
+    gasPrice
+  );
+  const launchpadAddress = await broadcastDeployment(
+    'LaunchpadFactory',
+    launchpadRequest,
+    wallet,
+    provider,
+    podProvider
+  );
+
+  const launchpadInterface = new Interface(launchpadArtifact.abi);
+  const treasuryCallData = launchpadInterface.encodeFunctionData('treasury');
+  const treasuryCall = await provider.call({
+    to: launchpadAddress,
+    data: treasuryCallData
+  });
+  const parsedTreasury = launchpadInterface.decodeFunctionResult(
+    'treasury',
+    treasuryCall
+  )[0];
+
+  const deployment = {
+    dexFactory: dexFactoryAddress,
+    router: dexRouterAddress,
+    launchpad: launchpadAddress,
+    treasury: parsedTreasury
+  };
+
+  const outputPath = path.join(projectRoot, 'deployment-foundry.json');
+  fs.writeFileSync(outputPath, `${JSON.stringify(deployment, null, 2)}\n`);
+  console.log('Deployment complete via Foundry/Pod SDK:', deployment);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Foundry configuration aligning solc/optimizer settings with Hardhat and enabling FFI + Pod RPC endpoint wiring
- create a Forge script that defers to a Pod SDK Node helper for legacy-transaction deployments mirroring the Hardhat flow
- document the new Foundry + Pod SDK workflow, required environment variables, and ship supporting dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5d01deb6c832f931f4fc585a3472c