### PR TITLE
Gate bonding curve graduation on target market cap

### DIFF
--- a/contracts/core/BondingCurve.sol
+++ b/contracts/core/BondingCurve.sol
@@ -36,6 +36,7 @@ contract BondingCurve is ReentrancyGuard {
 
     error Unauthorized();
     error InvalidState();
+    error InsufficientMarketCap();
 
     constructor(
         address factory_,
@@ -109,6 +110,7 @@ contract BondingCurve is ReentrancyGuard {
     }
 
     function graduate() external nonReentrant {
+        if (marketCap() < targetMarketCap) revert InsufficientMarketCap();
         _graduate();
     }
 

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -43,6 +43,18 @@ expectContains(
 
 expectContains(
   path.join(contractsDir, 'core', 'BondingCurve.sol'),
+  /error InsufficientMarketCap\(\);/,
+  'BondingCurve must define InsufficientMarketCap error'
+);
+
+expectContains(
+  path.join(contractsDir, 'core', 'BondingCurve.sol'),
+  /function graduate\(\) external nonReentrant {\s*if \(marketCap\(\) < targetMarketCap\) revert InsufficientMarketCap\(\);/,
+  'BondingCurve graduate must revert when market cap is below target'
+);
+
+expectContains(
+  path.join(contractsDir, 'core', 'BondingCurve.sol'),
   /receive\(\) external payable {\s*if \(msg\.sender != factory\) revert Unauthorized\(\);\s*reservePEth \+= msg\.value;\s*}/,
   'BondingCurve receive() must gate funding to the factory and update reservePEth'
 );


### PR DESCRIPTION
## Summary
- add an explicit InsufficientMarketCap error to the bonding curve
- require the market cap threshold before allowing manual graduation
- extend static tests to cover the new guard rails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5d01de250832f8a4504e8043b3093